### PR TITLE
Refresh atproto session on failure & invalidate iron session

### DIFF
--- a/backend/index.ts
+++ b/backend/index.ts
@@ -1,6 +1,5 @@
 import { Hono } from "https://esm.sh/hono";
-import { createATProtoOAuth } from "jsr:@tijs/atproto-oauth-hono@^0.3.2";
-import { DrizzleStorage } from "jsr:@tijs/atproto-oauth-hono@^0.3.2/drizzle";
+import { oauth } from "./services/oauth.ts";
 import { db, initializeTables } from "./database/db.ts";
 import { staticRoutes } from "./routes/static.ts";
 import { bookmarksApi } from "./routes/bookmarks.ts";
@@ -12,23 +11,7 @@ await initializeTables();
 // Create the main app
 const app = new Hono();
 
-// Get base URL and cookie secret from environment
-const BASE_URL = Deno.env.get("BASE_URL") ||
-  "https://kipclip-tijs.val.town";
-const COOKIE_SECRET = Deno.env.get("COOKIE_SECRET");
-
-if (!COOKIE_SECRET) {
-  throw new Error("COOKIE_SECRET environment variable is required");
-}
-
-// Create OAuth integration with DrizzleStorage
-export const oauth = createATProtoOAuth({
-  baseUrl: BASE_URL,
-  appName: "kipclip",
-  cookieSecret: COOKIE_SECRET,
-  sessionTtl: 60 * 60 * 24 * 30, // 30 days in seconds
-  storage: new DrizzleStorage(db),
-});
+// oauth is created in services/oauth.ts
 
 // Note: No canonical-host redirect; app runs purely as a standard website
 

--- a/backend/routes/tags.ts
+++ b/backend/routes/tags.ts
@@ -8,7 +8,8 @@ import type {
   UpdateTagRequest,
   UpdateTagResponse,
 } from "../../shared/types.ts";
-import { oauth } from "../index.ts";
+import { getAuthSession, AuthInvalidError, clearSidCookieHeader } from
+  "../services/auth.ts";
 
 const TAG_COLLECTION = "com.kipclip.tag";
 
@@ -18,53 +19,7 @@ export const tagsApi = new Hono();
  * Get authenticated user session from OAuth
  * Extracts session cookie and gets OAuth session from storage
  */
-async function getAuthSession(req: Request) {
-  // Extract session cookie
-  const cookieHeader = req.headers.get("cookie");
-  if (!cookieHeader || !cookieHeader.includes("sid=")) {
-    throw new Error("Not authenticated");
-  }
-
-  const sessionCookie = cookieHeader
-    .split(";")
-    .find((c) => c.trim().startsWith("sid="))
-    ?.split("=")[1];
-
-  if (!sessionCookie) {
-    throw new Error("Not authenticated");
-  }
-
-  // Unseal session data to get DID - use the COOKIE_SECRET from env
-  const { unsealData } = await import("npm:iron-session@8.0.4");
-  const COOKIE_SECRET = Deno.env.get("COOKIE_SECRET");
-
-  if (!COOKIE_SECRET) {
-    console.error("COOKIE_SECRET environment variable not set");
-    throw new Error("Server configuration error");
-  }
-
-  const sessionData = await unsealData(decodeURIComponent(sessionCookie), {
-    password: COOKIE_SECRET,
-  });
-
-  const userDid = (sessionData as any)?.did || (sessionData as any)?.userId ||
-    (sessionData as any)?.sub;
-
-  if (!userDid) {
-    console.error("No DID found in session data:", sessionData);
-    throw new Error("Not authenticated");
-  }
-
-  // Get OAuth session using sessions manager
-  const oauthSession = await oauth.sessions.getOAuthSession(userDid);
-
-  if (!oauthSession) {
-    console.error("No OAuth session found for DID:", userDid);
-    throw new Error("OAuth session not found");
-  }
-
-  return oauthSession;
-}
+// use shared getAuthSession from services/auth.ts
 
 /**
  * List user's tags
@@ -104,6 +59,11 @@ tagsApi.get("/tags", async (c) => {
     return c.json(result);
   } catch (error: any) {
     console.error("Error listing tags:", error);
+
+    if (error instanceof AuthInvalidError) {
+      c.header("Set-Cookie", clearSidCookieHeader());
+      return c.json({ error: "Authentication invalid" }, 401);
+    }
 
     // If collection doesn't exist yet, return empty array
     if (error.message?.includes("not found") || error.status === 400) {

--- a/backend/services/auth.ts
+++ b/backend/services/auth.ts
@@ -1,0 +1,147 @@
+import { oauth } from "./oauth.ts";
+
+export class AuthInvalidError extends Error {
+  constructor(message?: string) {
+    super(message || "Authentication invalid");
+    this.name = "AuthInvalidError";
+  }
+}
+
+// Returns a Set-Cookie header string that clears the iron session cookie used
+// by the OAuth package. We use conservative defaults (HttpOnly, Path=/, Max-Age=0)
+export function clearSidCookieHeader(): string {
+  // Note: mirror attributes used by the OAuth package as closely as possible
+  return [
+    `sid=;`,
+    `Path=/;`,
+    `HttpOnly;`,
+    `SameSite=Lax;`,
+    `Max-Age=0;`,
+    `Expires=Thu, 01 Jan 1970 00:00:00 GMT;`,
+    // If running over HTTPS (recommended) the Secure flag should be set.
+    `Secure`,
+  ].join(" ");
+}
+
+/**
+ * Get authenticated OAuth session for a request and return a session-like
+ * object where `makeRequest` is wrapped to automatically attempt a refresh
+ * when a PDS request fails due to an expired/invalid atproto session.
+ *
+ * Throws AuthInvalidError when the session cannot be refreshed and should be
+ * removed from the user's iron session cookie.
+ */
+export async function getAuthSession(req: Request) {
+  // Extract session cookie
+  const cookieHeader = req.headers.get("cookie");
+  if (!cookieHeader || !cookieHeader.includes("sid=")) {
+    throw new Error("Not authenticated");
+  }
+
+  const sessionCookie = cookieHeader
+    .split(";")
+    .find((c) => c.trim().startsWith("sid="))
+    ?.split("=")[1];
+
+  if (!sessionCookie) {
+    throw new Error("Not authenticated");
+  }
+
+  // Unseal session data to get DID - use the COOKIE_SECRET from env
+  const { unsealData } = await import("npm:iron-session@8.0.4");
+  const COOKIE_SECRET = Deno.env.get("COOKIE_SECRET");
+
+  if (!COOKIE_SECRET) {
+    console.error("COOKIE_SECRET environment variable not set");
+    throw new Error("Server configuration error");
+  }
+
+  const sessionData = await unsealData(decodeURIComponent(sessionCookie), {
+    password: COOKIE_SECRET,
+  });
+
+  const userDid = (sessionData as any)?.did || (sessionData as any)?.userId ||
+    (sessionData as any)?.sub;
+
+  if (!userDid) {
+    console.error("No DID found in session data:", sessionData);
+    throw new Error("Not authenticated");
+  }
+
+  // Get OAuth session using sessions manager
+  let oauthSession = await oauth.sessions.getOAuthSession(userDid);
+
+  if (!oauthSession) {
+    console.error("No OAuth session found for DID:", userDid);
+    throw new Error("OAuth session not found");
+  }
+
+  // Wrap makeRequest to attempt refresh on auth-related failures.
+  async function makeRequest(
+    method: string,
+    url: string,
+    options?: any,
+  ): Promise<Response> {
+    // Helper to execute request
+    const doRequest = async (sess: any) => {
+      return sess.makeRequest(method, url, options);
+    };
+
+    // First attempt
+    let resp = await doRequest(oauthSession);
+
+    // If response indicates an authorization problem, try to refresh once.
+    if (
+      resp.status === 401 ||
+      resp.status === 403 ||
+      // Some PDS return 500 when session is invalid/expired — treat as refreshable
+      resp.status === 500
+    ) {
+      // Try to read body for debugging/logging (non-blocking)
+      let bodyText = "";
+      try {
+        bodyText = await resp.text();
+      } catch (_e) {
+        // ignore
+      }
+      console.warn(
+        `PDS request returned ${resp.status}, attempting to refresh atproto session for ${userDid}: ${bodyText}`,
+      );
+
+      // Attempt refresh using the sessions manager. We assume the sessions
+      // manager exposes a refresh method; if not available, fall back to
+      // deleting the session and signaling invalid auth.
+      try {
+        // Best-effort: call known refresh method names if present
+        if (typeof oauth.sessions.refreshOAuthSession === "function") {
+          oauthSession = await oauth.sessions.refreshOAuthSession(userDid);
+        } else if (typeof oauth.sessions.refresh === "function") {
+          oauthSession = await oauth.sessions.refresh(userDid);
+        } else {
+          // No refresh API available
+          throw new Error("No refresh API available");
+        }
+      } catch (refreshErr) {
+        console.error("Failed to refresh atproto session:", refreshErr);
+        // Signal to caller that the iron session must be invalidated
+        throw new AuthInvalidError("Failed to refresh atproto session");
+      }
+
+      if (!oauthSession) {
+        console.error("Refresh returned no session for DID:", userDid);
+        throw new AuthInvalidError("Failed to refresh atproto session");
+      }
+
+      // Retry request with refreshed session
+      resp = await doRequest(oauthSession);
+    }
+
+    return resp;
+  }
+
+  // Return session object but override makeRequest
+  return {
+    ...oauthSession,
+    makeRequest,
+  } as any;
+}

--- a/backend/services/oauth.ts
+++ b/backend/services/oauth.ts
@@ -1,0 +1,18 @@
+import { createATProtoOAuth } from "jsr:@tijs/atproto-oauth-hono@^0.3.2";
+import { DrizzleStorage } from "jsr:@tijs/atproto-oauth-hono@^0.3.2/drizzle";
+import { db } from "../database/db.ts";
+
+const BASE_URL = Deno.env.get("BASE_URL") || "https://kipclip-tijs.val.town";
+const COOKIE_SECRET = Deno.env.get("COOKIE_SECRET");
+
+if (!COOKIE_SECRET) {
+  throw new Error("COOKIE_SECRET environment variable is required");
+}
+
+export const oauth = createATProtoOAuth({
+  baseUrl: BASE_URL,
+  appName: "kipclip",
+  cookieSecret: COOKIE_SECRET,
+  sessionTtl: 60 * 60 * 24 * 30,
+  storage: new DrizzleStorage(db),
+});


### PR DESCRIPTION
Attempt to refresh atproto session when PDS calls fail due to authorization errors; on failed refresh, clear iron session cookie (sid) so the user is logged out. Adds services/auth.ts with a wrapped makeRequest, and updates routes to use it.