### PR TITLE
Fix login redirect parameter preservation in bookmarklet flow

### DIFF
--- a/frontend/components/Login.tsx
+++ b/frontend/components/Login.tsx
@@ -11,8 +11,17 @@ export function Login() {
 
     setLoading(true);
     try {
+      // Preserve redirect parameter if present
+      const params = new URLSearchParams(globalThis.location.search);
+      const redirect = params.get("redirect");
+
+      let loginUrl = `/login?handle=${encodeURIComponent(handle)}`;
+      if (redirect) {
+        loginUrl += `&redirect=${encodeURIComponent(redirect)}`;
+      }
+
       // Redirect to OAuth login
-      globalThis.location.href = `/login?handle=${encodeURIComponent(handle)}`;
+      globalThis.location.href = loginUrl;
     } catch (error) {
       console.error("Login failed:", error);
       setLoading(false);


### PR DESCRIPTION
When a logged-out user tries to save a bookmark via the bookmarklet, they're redirected to /login?redirect=/save?url=... but the redirect parameter was being lost when submitting the login form. This caused the OAuth flow to not know where to redirect back to, resulting in an "invalid handle error".

Now the Login component preserves the redirect parameter when constructing the OAuth login URL, allowing the flow to complete successfully and redirect back to the save page.

Fixes #3 

🤖 Generated with [Claude Code](https://claude.com/claude-code)