### PR TITLE
Update to atproto-oauth-hono v2.0.0

### DIFF
--- a/backend/index.ts
+++ b/backend/index.ts
@@ -1,6 +1,6 @@
 import { Hono } from "https://esm.sh/hono";
-import { createATProtoOAuth } from "jsr:@tijs/atproto-oauth-hono@^2.0.0";
-import { DrizzleStorage } from "jsr:@tijs/atproto-oauth-hono@^2.0.0/drizzle";
+import { createATProtoOAuth } from "jsr:@tijs/atproto-oauth-hono@^2.0.1";
+import { DrizzleStorage } from "jsr:@tijs/atproto-oauth-hono@^2.0.1/drizzle";
 import { db, initializeTables } from "./database/db.ts";
 import { staticRoutes } from "./routes/static.ts";
 import { bookmarksApi } from "./routes/bookmarks.ts";

--- a/backend/services/auth.ts
+++ b/backend/services/auth.ts
@@ -1,6 +1,6 @@
 import { oauth } from "../index.ts";
 import type { Context } from "https://esm.sh/hono";
-import type { SessionInterface } from "jsr:@tijs/atproto-oauth-hono@^2.0.0";
+import type { SessionInterface } from "jsr:@tijs/atproto-oauth-hono@^2.0.1";
 import {
   NetworkError,
   RefreshTokenExpiredError,
@@ -8,7 +8,7 @@ import {
   SessionError,
   SessionNotFoundError,
   TokenExchangeError,
-} from "jsr:@tijs/atproto-oauth-hono@^2.0.0";
+} from "jsr:@tijs/atproto-oauth-hono@^2.0.1";
 
 /**
  * Get authenticated user session from OAuth with automatic token refresh.


### PR DESCRIPTION
## Summary

Updates kipclip-appview to use the latest atproto-oauth-hono v2.0.0, which includes:
- Minimal session manager architecture (hono-oauth-sessions 2.0.0)
- Removes displayName/avatar from session validation responses
- New getProfile() helper for fetching AT Protocol profile data

## Changes

- **backend/index.ts**: Update atproto-oauth-hono imports from ^1.0.2 → ^2.0.0
- **backend/services/auth.ts**: 
  - Remove direct `hono-oauth-sessions` dependency
  - Import `SessionInterface` from `atproto-oauth-hono` instead
  - Update error imports to v2.0.0

## Impact Analysis

✅ **No Breaking Changes for kipclip**

The breaking changes in atproto-oauth-hono v2.0.0 do NOT affect kipclip because:

- kipclip only uses `did` and `handle` from sessions (not the removed `displayName`/`avatar` fields)
- Frontend components (`App.tsx`, `Save.tsx`, `UserMenu.tsx`) only display `@{handle}`
- No profile data is currently fetched or displayed
- `oauth.sessions.getOAuthSession()` interface is unchanged

## Architecture Improvements

- ✅ Cleaner dependency graph - no direct hono-oauth-sessions dependency
- ✅ All OAuth functionality accessed through single atproto-oauth-hono package
- ✅ Separation of concerns: generic session management vs AT Protocol-specific features

## Testing Checklist

Before merging, verify:

- [ ] Application starts without errors
- [ ] Login flow completes successfully  
- [ ] `/api/auth/session` returns `{did, handle}`
- [ ] Authenticated bookmark operations work
- [ ] Authenticated tag operations work
- [ ] Token refresh happens automatically
- [ ] Logout clears session
- [ ] Public shared bookmarks still accessible
- [ ] Frontend displays handle correctly
- [ ] No console errors on session check

## Migration Notes

This is a low-risk upgrade because:
- Only 2 files changed
- No logic changes, just dependency version updates
- Well-isolated OAuth integration
- kipclip's minimal session usage already aligned with v2.0.0's philosophy

## Future Enhancement (Optional)

If we want to add user avatars/display names later, we can use the new `oauth.getProfile(did)` helper:

```typescript
const profile = await oauth.getProfile(userDid);
if (profile) {
  console.log(profile.displayName, profile.avatar);
}
```