### PR TITLE
fix(deploy): default to production host + uncomment apex Caddy blocks

### DIFF
--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -34,26 +34,18 @@ staging.kipclip.com {
 	}
 }
 
-# Production apex + www. Commented out until phase 3 DNS flip — uncommenting
-# before DNS resolves to this box would cause Caddy to attempt Let's Encrypt
-# cert provisioning on every reload and burn through ACME rate limits.
-#
-# Activation steps at flip time:
-#   1. Confirm DNS A/AAAA records on kipclip.com + www.kipclip.com point at
-#      this box's public IP.
-#   2. Uncomment the blocks below.
-#   3. sudo systemctl reload caddy
-#   4. journalctl -u caddy -f — watch for successful ACME orders.
-#
-# kipclip.com {
-# 	import common
-#
-# 	log {
-# 		output file /var/log/caddy/kipclip.com.log
-# 		format console
-# 	}
-# }
-#
-# www.kipclip.com {
-# 	redir https://kipclip.com{uri} 308
-# }
+# Production apex + www. Activated on phase 3 DNS flip (2026-05-05). DNS
+# already resolves both names to this box, so Caddy can issue and renew
+# Let's Encrypt certs on every reload without ACME rate-limit risk.
+kipclip.com {
+	import common
+
+	log {
+		output file /var/log/caddy/kipclip.com.log
+		format console
+	}
+}
+
+www.kipclip.com {
+	redir https://kipclip.com{uri} 308
+}

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -1,10 +1,17 @@
 #!/usr/bin/env bash
-# Deploy kipclip to the staging box from the operator's machine.
-# Usage: ./deploy/deploy.sh [host]
-#   host defaults to staging.kipclip.com
+# Deploy kipclip to the production box from the operator's machine.
+#
+# Usage:
+#   ./deploy/deploy.sh                      # deploys to kipclip-box (production)
+#   ./deploy/deploy.sh staging.kipclip.com  # deploys to staging
+#   ./deploy/deploy.sh kipclip-box          # explicit production host
+#
+# Production target since the phase 3 DNS flip (2026-05-05). The
+# `kipclip-box` ssh alias resolves via ~/.ssh/config; defaulting to staging
+# would silently leave production stale.
 set -euo pipefail
 
-HOST="${1:-staging.kipclip.com}"
+HOST="${1:-kipclip-box}"
 APP_DIR="/var/lib/kipclip/app"
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 


### PR DESCRIPTION
## Summary

Two issues surfaced during the phase 4 deploy on 2026-05-06:

1. \`deploy.sh\` defaulted to \`staging.kipclip.com\`. After the phase 3 DNS flip on 2026-05-05, \`kipclip.com\` is the production target on the Hetzner box. A bare \`./deploy/deploy.sh\` would silently update only staging while leaving production stale.

2. The repo Caddyfile still had the \`kipclip.com\` + \`www.kipclip.com\` blocks commented out (a phase 3 readiness-window safeguard against ACME rate limits). Phase 3 cutover required the operator to uncomment those blocks on the box. deploy.sh's \`scp Caddyfile\` then silently re-commented them on every deploy, breaking TLS for the prod hostnames until the operator manually re-uncommented them.

## Fixes

- \`deploy.sh\` defaults to \`kipclip-box\` (the ssh alias for production). Pass \`staging.kipclip.com\` explicitly to deploy to staging.
- Repo Caddyfile uncomments the production blocks. DNS already resolves apex + www to the box, so Caddy issues / renews the Let's Encrypt certs idempotently on every reload.

## Test plan

- [x] \`deno task quality\` clean
- [x] Verified live on production: kipclip.com serves HTTP/2 200 with bundle \`fb8cb522\` (phase 4 build)
- [x] \`caddy validate --config /etc/caddy/Caddyfile\` on box reports valid configuration
- [ ] Next deploy with this PR merged: \`./deploy/deploy.sh\` (no args) targets prod and leaves the apex blocks uncommented post-scp

🤖 Generated with [Claude Code](https://claude.com/claude-code)