### PR TITLE
feat: tag sidebar search and Recent zone

### DIFF
--- a/docs/residual-review-findings/feat-tag-sidebar-search-recent.md
+++ b/docs/residual-review-findings/feat-tag-sidebar-search-recent.md
@@ -1,0 +1,38 @@
+---
+branch: feat/tag-sidebar-search-recent
+review_run: 20260509-213515-ccc65902
+review_mode: autofix
+created: 2026-05-09
+---
+
+# Residual Review Findings — feat/tag-sidebar-search-recent
+
+ce-code-review autofix run resolved all P0–P2 findings. The items below are
+residual P3 polish that did not meet the autofix threshold and remain for
+human or follow-up resolution. Source review summary:
+`/tmp/compound-engineering/ce-code-review/20260509-213515-ccc65902/summary.md`
+
+## Residuals
+
+- **#6 — P3 / gated_auto** — `frontend/components/TagSidebar.tsx` (desktop and
+  mobile search input sites). Extract a shared `<TagSearchInput>` subcomponent.
+  The two inputs differ only in container padding (~25 lines duplicated each).
+  A subcomponent prevents drift on future a11y or clear-button work and would
+  let the next consumer pick it up without wading through both branches.
+  Defer rationale: pure refactor, no behavior change, low value relative to
+  the surface area touched in this PR.
+
+- **#7 — P3 / gated_auto** — `frontend/components/TagSidebar.tsx`. Extract
+  `filterTags(tags, query)` and `resolveRecentTags(tags, recent, isSearching)`
+  into `frontend/utils/tag-sidebar-view.ts`. Enables pure unit tests for the
+  silently-handled "deleted-tag drop" case (a recent entry whose underlying
+  EnrichedTag was deleted from the user's library). Currently covered only by
+  manual smoke-test. Defer rationale: behavior already correct; the test is a
+  regression-safety net for a known invariant, not a bug fix.
+
+- **#8 — P3 / manual** — `frontend/components/TagSidebar.tsx` mobile bar.
+  The new search row currently sits between the horizontal tag scroll and the
+  selected-actions row (Clear / Share collection). Worth a manual viewport
+  check at 375px and 414px to decide whether search should sit *above* the
+  tag scroll instead of below. Discoverability vs. layout density trade-off.
+  Defer rationale: requires human visual judgment on a phone.

--- a/docs/residual-review-findings/feat-tag-sidebar-search-recent.md
+++ b/docs/residual-review-findings/feat-tag-sidebar-search-recent.md
@@ -8,19 +8,19 @@ created: 2026-05-09
 # Residual Review Findings — feat/tag-sidebar-search-recent
 
 ce-code-review autofix run resolved all P0–P2 findings. The items below are
-residual P3 polish that did not meet the autofix threshold and remain for
-human or follow-up resolution. Source review summary:
+residual P3 polish that did not meet the autofix threshold and remain for human
+or follow-up resolution. Source review summary:
 `/tmp/compound-engineering/ce-code-review/20260509-213515-ccc65902/summary.md`
 
 ## Residuals
 
 - **#6 — P3 / gated_auto** — `frontend/components/TagSidebar.tsx` (desktop and
   mobile search input sites). Extract a shared `<TagSearchInput>` subcomponent.
-  The two inputs differ only in container padding (~25 lines duplicated each).
-  A subcomponent prevents drift on future a11y or clear-button work and would
-  let the next consumer pick it up without wading through both branches.
-  Defer rationale: pure refactor, no behavior change, low value relative to
-  the surface area touched in this PR.
+  The two inputs differ only in container padding (~25 lines duplicated each). A
+  subcomponent prevents drift on future a11y or clear-button work and would let
+  the next consumer pick it up without wading through both branches. Defer
+  rationale: pure refactor, no behavior change, low value relative to the
+  surface area touched in this PR.
 
 - **#7 — P3 / gated_auto** — `frontend/components/TagSidebar.tsx`. Extract
   `filterTags(tags, query)` and `resolveRecentTags(tags, recent, isSearching)`
@@ -30,9 +30,9 @@ human or follow-up resolution. Source review summary:
   manual smoke-test. Defer rationale: behavior already correct; the test is a
   regression-safety net for a known invariant, not a bug fix.
 
-- **#8 — P3 / manual** — `frontend/components/TagSidebar.tsx` mobile bar.
-  The new search row currently sits between the horizontal tag scroll and the
-  selected-actions row (Clear / Share collection). Worth a manual viewport
-  check at 375px and 414px to decide whether search should sit *above* the
-  tag scroll instead of below. Discoverability vs. layout density trade-off.
-  Defer rationale: requires human visual judgment on a phone.
+- **#8 — P3 / manual** — `frontend/components/TagSidebar.tsx` mobile bar. The
+  new search row currently sits between the horizontal tag scroll and the
+  selected-actions row (Clear / Share collection). Worth a manual viewport check
+  at 375px and 414px to decide whether search should sit _above_ the tag scroll
+  instead of below. Discoverability vs. layout density trade-off. Defer
+  rationale: requires human visual judgment on a phone.

--- a/frontend/components/TagInput.tsx
+++ b/frontend/components/TagInput.tsx
@@ -47,6 +47,9 @@ export function TagInput({
   }
 
   function handleRemoveTag(tagValue: string) {
+    // Intentional: removing a tag still counts as engagement, so it surfaces
+    // in the Recent zone alongside add/toggle. "Tags I'm working with" is
+    // the model, not "tags I'm filtering by."
     trackTagUsage(tagValue);
     onTagsChange(tags.filter((t) => t !== tagValue));
   }

--- a/frontend/components/TagInput.tsx
+++ b/frontend/components/TagInput.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import type { KeyboardEvent } from "react";
 import type { EnrichedTag } from "../../shared/types.ts";
+import { useApp } from "../context/AppContext.tsx";
 
 interface TagInputProps {
   tags: string[];
@@ -17,6 +18,7 @@ export function TagInput({
   disabled = false,
   compact = false,
 }: TagInputProps) {
+  const { trackTagUsage } = useApp();
   const [tagInput, setTagInput] = useState("");
   const [showSuggestions, setShowSuggestions] = useState(false);
 
@@ -37,12 +39,15 @@ export function TagInput({
     const existing = availableTags.find(
       (t) => t.value.toLowerCase() === tagValue.toLowerCase(),
     );
-    onTagsChange([...tags, existing ? existing.value : tagValue]);
+    const resolved = existing ? existing.value : tagValue;
+    trackTagUsage(resolved);
+    onTagsChange([...tags, resolved]);
     setTagInput("");
     setShowSuggestions(false);
   }
 
   function handleRemoveTag(tagValue: string) {
+    trackTagUsage(tagValue);
     onTagsChange(tags.filter((t) => t !== tagValue));
   }
 

--- a/frontend/components/TagSidebar.tsx
+++ b/frontend/components/TagSidebar.tsx
@@ -50,6 +50,15 @@ export function TagSidebar() {
     return resolved;
   }, [tags, recentTags, isSearching]);
 
+  // Tags shown in the alphabetical list, excluding those already surfaced in
+  // the Recent zone — avoids visual duplicates and (on mobile, where Recent
+  // and the rest share a single <ul>) duplicate React keys.
+  const restTags = useMemo(() => {
+    if (recentTagObjects.length === 0) return filteredTags;
+    const recentUris = new Set(recentTagObjects.map((t) => t.uri));
+    return filteredTags.filter((t) => !recentUris.has(t.uri));
+  }, [filteredTags, recentTagObjects]);
+
   // Manual refresh (for retry button)
   async function loadTags() {
     setRefreshing(true);
@@ -239,13 +248,13 @@ export function TagSidebar() {
               <ul className="flex gap-2 flex-shrink-0 items-center">
                 {!isSearching && recentTagObjects.map(renderTag)}
                 {!isSearching && recentTagObjects.length > 0 &&
-                  filteredTags.length > 0 && (
+                  restTags.length > 0 && (
                   <li
                     aria-hidden="true"
                     className="border-l border-gray-300 h-6 mx-1 flex-shrink-0"
                   />
                 )}
-                {filteredTags.map(renderTag)}
+                {restTags.map(renderTag)}
               </ul>
             )}
           <button
@@ -286,11 +295,14 @@ export function TagSidebar() {
               />
             </svg>
             <input
-              type="text"
+              type="search"
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
               onKeyDown={(e) => {
-                if (e.key === "Escape") setSearchQuery("");
+                if (e.key === "Escape") {
+                  setSearchQuery("");
+                  (e.target as HTMLInputElement).blur();
+                }
               }}
               placeholder="Search tags"
               aria-label="Search tags"
@@ -435,11 +447,14 @@ export function TagSidebar() {
               />
             </svg>
             <input
-              type="text"
+              type="search"
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
               onKeyDown={(e) => {
-                if (e.key === "Escape") setSearchQuery("");
+                if (e.key === "Escape") {
+                  setSearchQuery("");
+                  (e.target as HTMLInputElement).blur();
+                }
               }}
               placeholder="Search tags"
               aria-label="Search tags"
@@ -474,10 +489,10 @@ export function TagSidebar() {
                     </ul>
                   </section>
                 )}
-                {recentTagObjects.length > 0 && filteredTags.length > 0 && (
+                {recentTagObjects.length > 0 && restTags.length > 0 && (
                   <div className="border-t border-gray-200 mx-3 my-3" />
                 )}
-                <ul className="space-y-1">{filteredTags.map(renderTag)}</ul>
+                <ul className="space-y-1">{restTags.map(renderTag)}</ul>
               </>
             )}
         </div>

--- a/frontend/components/TagSidebar.tsx
+++ b/frontend/components/TagSidebar.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { toast } from "sonner";
 import { AddTag } from "./AddTag.tsx";
 import { EditTag } from "./EditTag.tsx";
@@ -17,6 +17,7 @@ export function TagSidebar() {
     addTag,
     updateTag,
     deleteTag,
+    recentTags,
     session,
   } = useApp();
   const formatDate = useDateFormat();
@@ -26,6 +27,28 @@ export function TagSidebar() {
   const [editingTag, setEditingTag] = useState<any>(null);
   const [error, setError] = useState<string | null>(null);
   const [refreshing, setRefreshing] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
+
+  const trimmedQuery = searchQuery.trim().toLowerCase();
+  const isSearching = trimmedQuery.length > 0;
+
+  const filteredTags = useMemo(() => {
+    if (!isSearching) return tags;
+    return tags.filter((t) => t.value.toLowerCase().includes(trimmedQuery));
+  }, [tags, trimmedQuery, isSearching]);
+
+  // Resolve recent tag strings to live EnrichedTag objects, dropping any
+  // entries whose tag was deleted from the user's library.
+  const recentTagObjects = useMemo(() => {
+    if (isSearching || recentTags.length === 0) return [];
+    const byLower = new Map(tags.map((t) => [t.value.toLowerCase(), t]));
+    const resolved: typeof tags = [];
+    for (const v of recentTags) {
+      const match = byLower.get(v.toLowerCase());
+      if (match) resolved.push(match);
+    }
+    return resolved;
+  }, [tags, recentTags, isSearching]);
 
   // Manual refresh (for retry button)
   async function loadTags() {
@@ -206,9 +229,23 @@ export function TagSidebar() {
                 No tags yet
               </div>
             )
+            : isSearching && filteredTags.length === 0
+            ? (
+              <div className="flex-1 text-xs text-gray-500 flex-shrink-0">
+                No matches
+              </div>
+            )
             : (
-              <ul className="flex gap-2 flex-shrink-0">
-                {tags.map(renderTag)}
+              <ul className="flex gap-2 flex-shrink-0 items-center">
+                {!isSearching && recentTagObjects.map(renderTag)}
+                {!isSearching && recentTagObjects.length > 0 &&
+                  filteredTags.length > 0 && (
+                  <li
+                    aria-hidden="true"
+                    className="border-l border-gray-300 h-6 mx-1 flex-shrink-0"
+                  />
+                )}
+                {filteredTags.map(renderTag)}
               </ul>
             )}
           <button
@@ -232,6 +269,35 @@ export function TagSidebar() {
             </svg>
           </button>
         </div>
+        {/* Search row */}
+        {tags.length > 0 && (
+          <div className="relative px-3 pb-2">
+            <svg
+              className="w-4 h-4 absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 pointer-events-none"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M21 21l-4.35-4.35M17 11a6 6 0 11-12 0 6 6 0 0112 0z"
+              />
+            </svg>
+            <input
+              type="text"
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Escape") setSearchQuery("");
+              }}
+              placeholder="Search tags"
+              aria-label="Search tags"
+              className="w-full bg-transparent border-0 border-b border-gray-300 focus:border-coral outline-none pl-7 pr-1 py-1.5 text-sm placeholder-gray-400"
+            />
+          </div>
+        )}
         {/* Action row: appears when tags are selected */}
         {selectedTags.size > 0 && (
           <div className="flex items-center gap-2 px-3 py-2 border-t border-gray-100">
@@ -353,6 +419,35 @@ export function TagSidebar() {
           </div>
         )}
 
+        {tags.length > 0 && (
+          <div className="relative mb-3">
+            <svg
+              className="w-4 h-4 absolute left-1 top-1/2 -translate-y-1/2 text-gray-400 pointer-events-none"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M21 21l-4.35-4.35M17 11a6 6 0 11-12 0 6 6 0 0112 0z"
+              />
+            </svg>
+            <input
+              type="text"
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Escape") setSearchQuery("");
+              }}
+              placeholder="Search tags"
+              aria-label="Search tags"
+              className="w-full bg-transparent border-0 border-b border-gray-300 focus:border-coral outline-none pl-7 pr-1 py-2 text-sm placeholder-gray-400"
+            />
+          </div>
+        )}
+
         <div className="flex-1 overflow-y-auto overflow-x-hidden">
           {tags.length === 0
             ? (
@@ -361,7 +456,30 @@ export function TagSidebar() {
                 <p className="text-xs">Create your first tag to get started</p>
               </div>
             )
-            : <ul className="space-y-1">{tags.map(renderTag)}</ul>}
+            : isSearching && filteredTags.length === 0
+            ? (
+              <div className="text-center py-6 text-gray-500 text-xs">
+                No tags match "{searchQuery.trim()}"
+              </div>
+            )
+            : (
+              <>
+                {recentTagObjects.length > 0 && (
+                  <section className="mb-2">
+                    <h3 className="text-[10px] font-semibold uppercase tracking-wider text-gray-400 px-3 mt-1 mb-2">
+                      Recent
+                    </h3>
+                    <ul className="space-y-1">
+                      {recentTagObjects.map(renderTag)}
+                    </ul>
+                  </section>
+                )}
+                {recentTagObjects.length > 0 && filteredTags.length > 0 && (
+                  <div className="border-t border-gray-200 mx-3 my-3" />
+                )}
+                <ul className="space-y-1">{filteredTags.map(renderTag)}</ul>
+              </>
+            )}
         </div>
       </aside>
 

--- a/frontend/context/AppContext.tsx
+++ b/frontend/context/AppContext.tsx
@@ -31,6 +31,11 @@ import {
   toggleTagInQuery,
 } from "../../shared/search-query.ts";
 import { connectLiveEvents, type LiveEvent } from "../lib/live-events.ts";
+import {
+  loadRecentTags,
+  nextRecentTags,
+  saveRecentTags,
+} from "../utils/recent-tags.ts";
 
 const DEFAULT_SETTINGS: UserSettings = {
   instapaperEnabled: false,
@@ -216,6 +221,10 @@ interface AppContextValue extends AppState {
   deleteTag: (uri: string) => void;
   loadTags: () => Promise<void>;
 
+  // Recent tag actions
+  recentTags: string[];
+  trackTagUsage: (tagValue: string) => void;
+
   // Combined initial data loading (avoids token refresh race condition)
   loadInitialData: () => Promise<void>;
   // Force a full refresh, paginating through every page.
@@ -282,6 +291,17 @@ export function AppProvider({ children }: { children: ReactNode }) {
   const [readingListSelectedTags, setReadingListSelectedTags] = useState<
     Set<string>
   >(new Set());
+  const [recentTags, setRecentTags] = useState<string[]>(() =>
+    loadRecentTags()
+  );
+
+  function trackTagUsage(tagValue: string) {
+    setRecentTags((prev) => {
+      const next = nextRecentTags(prev, tagValue);
+      saveRecentTags(next);
+      return next;
+    });
+  }
   const [bookmarkSearchQuery, setBookmarkSearchQuery] = useState(() => {
     const params = new URLSearchParams(globalThis.location.search);
     return params.get("q") || "";
@@ -686,6 +706,7 @@ export function AppProvider({ children }: { children: ReactNode }) {
 
   // Filter actions
   function toggleTag(tagValue: string) {
+    trackTagUsage(tagValue);
     setBookmarkSearchQuery(toggleTagInQuery(bookmarkSearchQuery, tagValue));
   }
 
@@ -900,6 +921,8 @@ export function AppProvider({ children }: { children: ReactNode }) {
     updateTag,
     deleteTag,
     loadTags,
+    recentTags,
+    trackTagUsage,
     loadInitialData,
     refreshData,
     toggleTag,

--- a/frontend/utils/recent-tags.ts
+++ b/frontend/utils/recent-tags.ts
@@ -9,6 +9,7 @@ const STORAGE_KEY = "kipclip:recent-tags";
 export const MAX_RECENT_TAGS = 8;
 
 export function loadRecentTags(): string[] {
+  if (typeof localStorage === "undefined") return [];
   try {
     const stored = localStorage.getItem(STORAGE_KEY);
     if (!stored) return [];
@@ -21,9 +22,10 @@ export function loadRecentTags(): string[] {
 }
 
 export function saveRecentTags(tags: string[]): void {
+  if (typeof localStorage === "undefined") return;
   try {
     localStorage.setItem(STORAGE_KEY, JSON.stringify(tags));
-  } catch { /* localStorage unavailable */ }
+  } catch { /* localStorage unavailable or quota exceeded */ }
 }
 
 /**

--- a/frontend/utils/recent-tags.ts
+++ b/frontend/utils/recent-tags.ts
@@ -1,0 +1,40 @@
+/**
+ * Recent tags tracker.
+ * Tracks the last N tag values the user has touched (filtered, applied to a
+ * bookmark, removed) so the sidebar can surface them above the alphabetical
+ * list. Stored per-device in localStorage; not synced to PDS.
+ */
+
+const STORAGE_KEY = "kipclip:recent-tags";
+export const MAX_RECENT_TAGS = 8;
+
+export function loadRecentTags(): string[] {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (!stored) return [];
+    const parsed = JSON.parse(stored);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((v): v is string => typeof v === "string");
+  } catch {
+    return [];
+  }
+}
+
+export function saveRecentTags(tags: string[]): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(tags));
+  } catch { /* localStorage unavailable */ }
+}
+
+/**
+ * Compute the next recent-tags list after the user touches `tagValue`.
+ * Removes any case-insensitive match for the value, then unshifts the new
+ * value preserving its original casing, and clips to MAX_RECENT_TAGS.
+ */
+export function nextRecentTags(current: string[], tagValue: string): string[] {
+  const trimmed = tagValue.trim();
+  if (!trimmed) return current;
+  const lower = trimmed.toLowerCase();
+  const filtered = current.filter((t) => t.toLowerCase() !== lower);
+  return [trimmed, ...filtered].slice(0, MAX_RECENT_TAGS);
+}

--- a/tests/recent-tags.test.ts
+++ b/tests/recent-tags.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Tests for recent-tags localStorage helpers and pure reducer.
+ * Uses a localStorage mock since Deno doesn't provide one.
+ */
+
+import { assertEquals } from "@std/assert";
+import {
+  loadRecentTags,
+  MAX_RECENT_TAGS,
+  nextRecentTags,
+  saveRecentTags,
+} from "../frontend/utils/recent-tags.ts";
+
+const STORAGE_KEY = "kipclip:recent-tags";
+
+function mockLocalStorage(): {
+  restore: () => void;
+  store: Map<string, string>;
+} {
+  const store = new Map<string, string>();
+  const original = globalThis.localStorage;
+
+  Object.defineProperty(globalThis, "localStorage", {
+    value: {
+      getItem: (key: string) => store.get(key) ?? null,
+      setItem: (key: string, value: string) => store.set(key, value),
+      removeItem: (key: string) => store.delete(key),
+      clear: () => store.clear(),
+      get length() {
+        return store.size;
+      },
+      key: (_index: number) => null,
+    },
+    writable: true,
+    configurable: true,
+  });
+
+  return {
+    store,
+    restore: () => {
+      Object.defineProperty(globalThis, "localStorage", {
+        value: original,
+        writable: true,
+        configurable: true,
+      });
+    },
+  };
+}
+
+// ============================================================================
+// nextRecentTags (pure reducer)
+
+Deno.test("nextRecentTags inserts a new tag at the front of an empty list", () => {
+  assertEquals(nextRecentTags([], "swift"), ["swift"]);
+});
+
+Deno.test("nextRecentTags inserts a new tag at the front when list is non-empty", () => {
+  assertEquals(nextRecentTags(["swift"], "ai"), ["ai", "swift"]);
+});
+
+Deno.test("nextRecentTags moves an existing tag to the front without duplicating", () => {
+  assertEquals(
+    nextRecentTags(["c", "b", "swift", "a"], "swift"),
+    ["swift", "c", "b", "a"],
+  );
+});
+
+Deno.test("nextRecentTags dedupes case-insensitively and keeps the new casing", () => {
+  assertEquals(
+    nextRecentTags(["swift", "ai"], "Swift"),
+    ["Swift", "ai"],
+  );
+});
+
+Deno.test("nextRecentTags clips to MAX_RECENT_TAGS when adding the (N+1)th", () => {
+  const seven = ["a", "b", "c", "d", "e", "f", "g"];
+  // Add 8th: stays at MAX.
+  const eight = nextRecentTags(seven, "h");
+  assertEquals(eight.length, MAX_RECENT_TAGS);
+  assertEquals(eight[0], "h");
+  // Add 9th: drops the oldest (now at the tail).
+  const nine = nextRecentTags(eight, "i");
+  assertEquals(nine.length, MAX_RECENT_TAGS);
+  assertEquals(nine[0], "i");
+  assertEquals(nine.includes("g"), false, "oldest entry should be dropped");
+});
+
+Deno.test("nextRecentTags ignores empty/whitespace input", () => {
+  assertEquals(nextRecentTags(["swift"], ""), ["swift"]);
+  assertEquals(nextRecentTags(["swift"], "   "), ["swift"]);
+});
+
+Deno.test("nextRecentTags trims input before storing and comparing", () => {
+  assertEquals(nextRecentTags(["swift"], "  ai  "), ["ai", "swift"]);
+});
+
+// ============================================================================
+// loadRecentTags
+
+Deno.test("loadRecentTags returns [] when nothing stored", () => {
+  const mock = mockLocalStorage();
+  try {
+    assertEquals(loadRecentTags(), []);
+  } finally {
+    mock.restore();
+  }
+});
+
+Deno.test("loadRecentTags returns stored array of strings", () => {
+  const mock = mockLocalStorage();
+  try {
+    mock.store.set(STORAGE_KEY, JSON.stringify(["swift", "ai"]));
+    assertEquals(loadRecentTags(), ["swift", "ai"]);
+  } finally {
+    mock.restore();
+  }
+});
+
+Deno.test("loadRecentTags returns [] on corrupt JSON", () => {
+  const mock = mockLocalStorage();
+  try {
+    mock.store.set(STORAGE_KEY, "not json");
+    assertEquals(loadRecentTags(), []);
+  } finally {
+    mock.restore();
+  }
+});
+
+Deno.test("loadRecentTags returns [] when stored value is not an array", () => {
+  const mock = mockLocalStorage();
+  try {
+    mock.store.set(STORAGE_KEY, JSON.stringify({ swift: true }));
+    assertEquals(loadRecentTags(), []);
+  } finally {
+    mock.restore();
+  }
+});
+
+Deno.test("loadRecentTags filters out non-string array entries", () => {
+  const mock = mockLocalStorage();
+  try {
+    mock.store.set(STORAGE_KEY, JSON.stringify(["swift", 42, null, "ai"]));
+    assertEquals(loadRecentTags(), ["swift", "ai"]);
+  } finally {
+    mock.restore();
+  }
+});
+
+// ============================================================================
+// saveRecentTags
+
+Deno.test("saveRecentTags persists tags to localStorage", () => {
+  const mock = mockLocalStorage();
+  try {
+    saveRecentTags(["swift", "ai"]);
+    assertEquals(mock.store.get(STORAGE_KEY), JSON.stringify(["swift", "ai"]));
+  } finally {
+    mock.restore();
+  }
+});
+
+Deno.test("saveRecentTags then loadRecentTags round-trips correctly", () => {
+  const mock = mockLocalStorage();
+  try {
+    saveRecentTags(["swift", "ai", "atproto"]);
+    assertEquals(loadRecentTags(), ["swift", "ai", "atproto"]);
+  } finally {
+    mock.restore();
+  }
+});

--- a/tests/recent-tags.test.ts
+++ b/tests/recent-tags.test.ts
@@ -94,6 +94,17 @@ Deno.test("nextRecentTags trims input before storing and comparing", () => {
   assertEquals(nextRecentTags(["swift"], "  ai  "), ["ai", "swift"]);
 });
 
+Deno.test("nextRecentTags trim + case-insensitive dedupe combine", () => {
+  assertEquals(
+    nextRecentTags(["swift", "ai"], "  SWIFT  "),
+    ["SWIFT", "ai"],
+  );
+});
+
+Deno.test("MAX_RECENT_TAGS is 8 (canary — bump deliberately if changing)", () => {
+  assertEquals(MAX_RECENT_TAGS, 8);
+});
+
 // ============================================================================
 // loadRecentTags
 
@@ -166,5 +177,53 @@ Deno.test("saveRecentTags then loadRecentTags round-trips correctly", () => {
     assertEquals(loadRecentTags(), ["swift", "ai", "atproto"]);
   } finally {
     mock.restore();
+  }
+});
+
+Deno.test("saveRecentTags swallows quota-exceeded errors", () => {
+  const original = globalThis.localStorage;
+  Object.defineProperty(globalThis, "localStorage", {
+    value: {
+      getItem: () => null,
+      setItem: () => {
+        throw new Error("QuotaExceededError");
+      },
+      removeItem: () => {},
+      clear: () => {},
+      get length() {
+        return 0;
+      },
+      key: () => null,
+    },
+    writable: true,
+    configurable: true,
+  });
+  try {
+    // Must not throw.
+    saveRecentTags(["swift"]);
+  } finally {
+    Object.defineProperty(globalThis, "localStorage", {
+      value: original,
+      writable: true,
+      configurable: true,
+    });
+  }
+});
+
+Deno.test("loadRecentTags returns [] when localStorage is undefined (SSR)", () => {
+  const original = globalThis.localStorage;
+  Object.defineProperty(globalThis, "localStorage", {
+    value: undefined,
+    writable: true,
+    configurable: true,
+  });
+  try {
+    assertEquals(loadRecentTags(), []);
+  } finally {
+    Object.defineProperty(globalThis, "localStorage", {
+      value: original,
+      writable: true,
+      configurable: true,
+    });
   }
 });


### PR DESCRIPTION
## Summary

Tag sidebar with 1651+ entries was unnavigable. This adds an always-visible search input and an automatic Recent tags zone — the last 8 tags the user touched (filtered, applied to a bookmark, removed) surface above the alphabetical list. No user curation; software does the work.

- **Search:** Hairline-underline input at the top of the sidebar (desktop) and the mobile horizontal bar. Filters the list live by case-insensitive substring match. `type="search"` for native clear-X. ESC clears and blurs.
- **Recent:** Top-of-list zone, labeled "RECENT" on desktop. Updates from sidebar clicks (`toggleTag`) and any `TagInput` action — covers AddBookmark, EditBookmark, BulkTagModal via the shared input component.
- **Persistence:** localStorage under `kipclip:recent-tags`, dedupes case-insensitively, clipped to 8.
- **Mobile:** New search row beneath the tag scroll. Recent tags rendered first, vertical divider, alphabetical list after — shares one `<ul>` with deduped sources to avoid duplicate React keys.

No backend changes. No new schema. Pinned tags, hierarchical nesting, and tag manager were considered and intentionally deferred per `docs/plans/2026-05-09-005-feat-tag-sidebar-search-recent-plan.md`.

## Files

- `frontend/utils/recent-tags.ts` (new) — pure reducer + localStorage helpers, SSR-guarded
- `frontend/context/AppContext.tsx` — `recentTags` state and `trackTagUsage` exposed via context
- `frontend/components/TagInput.tsx` — `handleAddTag` / `handleRemoveTag` feed Recent
- `frontend/components/TagSidebar.tsx` — search input, Recent zone, mobile bar reordering, `restTags` deduplication
- `tests/recent-tags.test.ts` (new) — 18 unit tests covering dedupe, clip, trim, case-fold, corrupt JSON, quota throw, SSR

## Test plan

- [x] `deno task quality` (fmt, lint, audit, check, check:frontend) clean
- [x] `deno task test` — 419 passed / 0 failed
- [ ] Manual smoke on desktop: search filters list, ESC clears, Recent surfaces above alphabetical, divider hides when one side is empty
- [ ] Manual smoke on mobile (375px and 414px): search row stacks reasonably, recent tags lead the horizontal scroll, vertical divider before the rest
- [ ] Manual: deleting a tag in the user's library silently drops the stale Recent entry on next render

## Residual

P3 polish items recorded at `docs/residual-review-findings/feat-tag-sidebar-search-recent.md` (extract `<TagSearchInput>` subcomponent, extract `filterTags` / `resolveRecentTags` to pure utils, mobile layout placement check).
