### PR TITLE
feat: GET /api/stats/monthly for per-month MAU + signups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,10 @@ All notable changes to kipclip are documented in this file.
 
 ### Added
 
-- New public `GET /api/stats/monthly?months=N` endpoint returning per-month
-  MAU and signups for the last N calendar months (default 12, capped at 24).
-  Companion to `/api/stats`; powers the monthly bar charts on the
-  side-business dashboard after its migration off the Turso mirror.
+- New public `GET /api/stats/monthly?months=N` endpoint returning per-month MAU
+  and signups for the last N calendar months (default 12, capped at 24).
+  Companion to `/api/stats`; powers the monthly bar charts on the side-business
+  dashboard after its migration off the Turso mirror.
 
 ## [0.24.16] - 2026-05-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to kipclip are documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- New public `GET /api/stats/monthly?months=N` endpoint returning per-month
+  MAU and signups for the last N calendar months (default 12, capped at 24).
+  Companion to `/api/stats`; powers the monthly bar charts on the
+  side-business dashboard after its migration off the Turso mirror.
+
 ## [0.24.16] - 2026-05-20
 
 ### Changed

--- a/lib/stats-monthly.ts
+++ b/lib/stats-monthly.ts
@@ -1,0 +1,149 @@
+/**
+ * Per-month marketing metrics — calendar-month MAU and signups for the
+ * last N months. Companion to lib/stats.ts (lifetime totals); both are
+ * consumed by the side-business dashboard for monthly bar charts.
+ *
+ * Sources:
+ *   - mau:     COUNT(DISTINCT key) on iron_session_storage where
+ *              key LIKE 'session:did:%' AND updated_at falls in the
+ *              month's UTC range. Bounded by the 14-day session TTL —
+ *              months older than ~2 weeks back will be partial and will
+ *              continue to decay as iron-session evicts sessions. Only
+ *              the current calendar month is fully meaningful; callers
+ *              who want a frozen historical view should write each
+ *              month's MAU once and stop overwriting past values.
+ *   - signups: COUNT(*) on seen_dids where first_seen_at falls in the
+ *              month. Accurate going forward; the seen_dids backfill
+ *              migration stamped all pre-existing rows with the
+ *              migration timestamp, so the first month covered by the
+ *              backfill shows an outsized spike. Document this in the
+ *              consumer.
+ *
+ * Cached for 1h (much shorter than /api/stats because per-month MAU
+ * shifts intra-day as new sessions land).
+ */
+
+import { db } from "./db.ts";
+import { type CachedFetcher, createCachedFetcher } from "./cached-fetch.ts";
+
+const TTL_MS = 60 * 60 * 1000;
+const DEFAULT_MONTHS = 12;
+export const MAX_MONTHS = 24;
+
+export interface MonthlyStatsRow {
+  yearMonth: string;
+  mau: number;
+  signups: number;
+}
+
+export interface MonthlyStats {
+  months: MonthlyStatsRow[];
+  /** Inclusive current-month label, e.g. "2026-05". */
+  currentYearMonth: string;
+}
+
+function toNumber(raw: unknown): number {
+  const n = typeof raw === "number"
+    ? raw
+    : typeof raw === "bigint"
+    ? Number(raw)
+    : Number(raw ?? 0);
+  return Number.isFinite(n) ? n : 0;
+}
+
+function ymToUtcRangeMs(yearMonth: string): { startMs: number; endMs: number } {
+  const [y, m] = yearMonth.split("-").map(Number);
+  return { startMs: Date.UTC(y, m - 1, 1), endMs: Date.UTC(y, m, 1) };
+}
+
+function recentYearMonths(now: Date, count: number): string[] {
+  const out: string[] = [];
+  for (let i = count - 1; i >= 0; i--) {
+    const d = new Date(
+      Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - i, 1),
+    );
+    out.push(
+      `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, "0")}`,
+    );
+  }
+  return out;
+}
+
+const MAU_SQL = `
+  SELECT COUNT(DISTINCT key) AS n
+  FROM iron_session_storage
+  WHERE key LIKE 'session:did:%'
+    AND updated_at != ''
+    AND CAST(updated_at AS INTEGER) >= ?
+    AND CAST(updated_at AS INTEGER) < ?
+`;
+
+const SIGNUPS_SQL = `
+  SELECT COUNT(*) AS n
+  FROM seen_dids
+  WHERE first_seen_at >= ?
+    AND first_seen_at < ?
+`;
+
+async function fetchMonthlyStats(
+  months: number,
+  now: Date,
+): Promise<MonthlyStats> {
+  const yms = recentYearMonths(now, months);
+  const rows = await Promise.all(yms.map(async (ym) => {
+    const { startMs, endMs } = ymToUtcRangeMs(ym);
+    const [mauRows, signupsRows] = await Promise.all([
+      db.execute({ sql: MAU_SQL, args: [startMs, endMs] }),
+      db.execute({ sql: SIGNUPS_SQL, args: [startMs, endMs] }),
+    ]);
+    return {
+      yearMonth: ym,
+      mau: toNumber(mauRows.rows?.[0]?.[0]),
+      signups: toNumber(signupsRows.rows?.[0]?.[0]),
+    };
+  }));
+  return {
+    months: rows,
+    currentYearMonth: yms[yms.length - 1],
+  };
+}
+
+interface FetcherEntry {
+  months: number;
+  fetcher: CachedFetcher<MonthlyStats>;
+}
+
+// One cached fetcher per requested window. The dashboard only ever asks
+// for one value of `months` so this set stays bounded to a handful of
+// entries even in pathological cases — capped via MAX_MONTHS at the
+// route layer.
+const fetchers: FetcherEntry[] = [];
+
+export function getMonthlyStats(
+  months: number = DEFAULT_MONTHS,
+): Promise<{ data: MonthlyStats; stale: boolean }> {
+  const clamped = Math.min(Math.max(1, Math.floor(months)), MAX_MONTHS);
+  let entry = fetchers.find((f) => f.months === clamped);
+  if (!entry) {
+    entry = {
+      months: clamped,
+      fetcher: createCachedFetcher({
+        ttlMs: TTL_MS,
+        fetch: () => fetchMonthlyStats(clamped, new Date()),
+        fallback: { months: [], currentYearMonth: "" },
+        label: `stats-monthly-${clamped}`,
+      }),
+    };
+    fetchers.push(entry);
+  }
+  return entry.fetcher.get();
+}
+
+export const __testing__ = {
+  fetchMonthlyStats,
+  recentYearMonths,
+  ymToUtcRangeMs,
+  resetCache(): void {
+    fetchers.length = 0;
+  },
+};

--- a/routes/api/stats.ts
+++ b/routes/api/stats.ts
@@ -1,13 +1,20 @@
 /**
  * Public site-wide marketing stats.
  *
- *   GET /api/stats -- returns total user count (distinct DIDs that
- *                     have ever signed in). Cached for 24h. Backed by
- *                     lib/stats.ts so other surfaces can reuse it.
+ *   GET /api/stats          -- total user count (distinct DIDs that
+ *                              have ever signed in). Cached for 24h.
+ *                              Backed by lib/stats.ts.
+ *   GET /api/stats/monthly  -- per-month MAU + signups for the last
+ *                              ?months=N calendar months (default 12,
+ *                              capped at MAX_MONTHS). Cached for 1h.
+ *                              Backed by lib/stats-monthly.ts. See that
+ *                              module for the iron_session_storage TTL
+ *                              and seen_dids backfill caveats.
  */
 
 import type { App } from "@fresh/core";
 import { getStats } from "../../lib/stats.ts";
+import { getMonthlyStats, MAX_MONTHS } from "../../lib/stats-monthly.ts";
 
 export function registerStatsRoutes(app: App<unknown>): App<unknown> {
   app = app.get("/api/stats", async () => {
@@ -26,5 +33,33 @@ export function registerStatsRoutes(app: App<unknown>): App<unknown> {
       { headers },
     );
   });
+
+  app = app.get("/api/stats/monthly", async (ctx) => {
+    const raw = new URL(ctx.req.url).searchParams.get("months");
+    const months = raw === null ? 12 : Number(raw);
+    if (!Number.isFinite(months) || months < 1 || months > MAX_MONTHS) {
+      return new Response(
+        JSON.stringify({
+          error: `months must be an integer between 1 and ${MAX_MONTHS}`,
+        }),
+        { status: 400, headers: { "Content-Type": "application/json" } },
+      );
+    }
+    const { data, stale } = await getMonthlyStats(months);
+    const headers = new Headers({ "Content-Type": "application/json" });
+    headers.set(
+      "Cache-Control",
+      "public, max-age=300, stale-while-revalidate=3600",
+    );
+    return new Response(
+      JSON.stringify({
+        months: data.months,
+        currentYearMonth: data.currentYearMonth,
+        stale,
+      }),
+      { headers },
+    );
+  });
+
   return app;
 }

--- a/tests/stats-monthly.test.ts
+++ b/tests/stats-monthly.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Tests for GET /api/stats/monthly and the lib/stats-monthly aggregator.
+ * Uses the in-memory test database; main.ts runs migrations on import
+ * so iron_session_storage and seen_dids exist before fixture inserts.
+ */
+
+import "./test-setup.ts";
+
+import { assert, assertEquals } from "@std/assert";
+import { app } from "../main.ts";
+import { initOAuth } from "../lib/oauth-config.ts";
+import { db } from "../lib/db.ts";
+import { __testing__, MAX_MONTHS } from "../lib/stats-monthly.ts";
+
+initOAuth(new URL("https://kipclip.com"));
+const handler = app.handler();
+
+async function clearFixtures(): Promise<void> {
+  await db.execute({
+    sql: "DELETE FROM iron_session_storage WHERE key LIKE 'session:did:%'",
+    args: [],
+  });
+  await db.execute({ sql: "DELETE FROM seen_dids", args: [] });
+  __testing__.resetCache();
+}
+
+async function insertSession(did: string, updatedAtMs: number): Promise<void> {
+  await db.execute({
+    sql: `
+      INSERT INTO iron_session_storage (key, value, expires_at, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?)
+    `,
+    args: [
+      `session:did:plc:${did}`,
+      "{}",
+      String(updatedAtMs + 14 * 86_400_000),
+      String(updatedAtMs),
+      String(updatedAtMs),
+    ],
+  });
+}
+
+async function insertSeenDid(
+  did: string,
+  firstSeenAtMs: number,
+): Promise<void> {
+  await db.execute({
+    sql: `
+      INSERT INTO seen_dids (did, first_seen_at, last_seen_at)
+      VALUES (?, ?, ?)
+    `,
+    args: [`did:plc:${did}`, firstSeenAtMs, firstSeenAtMs],
+  });
+}
+
+Deno.test("recentYearMonths returns chronological list ending at current month", () => {
+  const now = new Date(Date.UTC(2026, 4, 15)); // 2026-05-15 UTC
+  const months = __testing__.recentYearMonths(now, 4);
+  assertEquals(months, ["2026-02", "2026-03", "2026-04", "2026-05"]);
+});
+
+Deno.test("ymToUtcRangeMs covers exactly the calendar month in UTC", () => {
+  const { startMs, endMs } = __testing__.ymToUtcRangeMs("2026-05");
+  assertEquals(startMs, Date.UTC(2026, 4, 1));
+  assertEquals(endMs, Date.UTC(2026, 5, 1));
+});
+
+Deno.test("fetchMonthlyStats counts distinct DIDs per month + signups", async () => {
+  await clearFixtures();
+  const may = Date.UTC(2026, 4, 10);
+  const apr = Date.UTC(2026, 3, 10);
+  // Two distinct DIDs active in May, one with multiple sessions (still 1).
+  await insertSession("alice", may);
+  await insertSession("bob", may + 1);
+  await db.execute({
+    sql:
+      `INSERT INTO iron_session_storage (key, value, expires_at, created_at, updated_at)
+          VALUES (?, ?, ?, ?, ?)`,
+    args: [
+      "session:did:plc:alice-other", // different key, same DID prefix would still count distinct
+      "{}",
+      String(may + 14 * 86_400_000),
+      String(may),
+      String(may),
+    ],
+  });
+  // One DID active only in April.
+  await insertSession("carol", apr);
+
+  // Signups: alice in April, bob in May.
+  await insertSeenDid("alice", apr);
+  await insertSeenDid("bob", may);
+
+  const now = new Date(Date.UTC(2026, 4, 20));
+  const stats = await __testing__.fetchMonthlyStats(3, now);
+
+  assertEquals(stats.currentYearMonth, "2026-05");
+  assertEquals(stats.months.map((m) => m.yearMonth), [
+    "2026-03",
+    "2026-04",
+    "2026-05",
+  ]);
+  // March: nobody.
+  assertEquals(stats.months[0].mau, 0);
+  assertEquals(stats.months[0].signups, 0);
+  // April: carol active, alice signed up.
+  assertEquals(stats.months[1].mau, 1);
+  assertEquals(stats.months[1].signups, 1);
+  // May: alice + bob + alice-other = 3 distinct session keys.
+  assertEquals(stats.months[2].mau, 3);
+  assertEquals(stats.months[2].signups, 1);
+});
+
+Deno.test("fetchMonthlyStats ignores empty updated_at sentinel rows", async () => {
+  await clearFixtures();
+  // Row with empty updated_at (rows that survived the column-add
+  // migration before they were re-touched). Must not contribute MAU.
+  await db.execute({
+    sql:
+      `INSERT INTO iron_session_storage (key, value, expires_at, created_at, updated_at)
+          VALUES (?, ?, ?, ?, ?)`,
+    args: ["session:did:plc:stale", "{}", null, "", ""],
+  });
+  const now = new Date(Date.UTC(2026, 4, 20));
+  const stats = await __testing__.fetchMonthlyStats(2, now);
+  for (const m of stats.months) assertEquals(m.mau, 0);
+});
+
+Deno.test("GET /api/stats/monthly returns months array + currentYearMonth", async () => {
+  await clearFixtures();
+  const now = Date.now();
+  await insertSession("a", now);
+  await insertSeenDid("a", now);
+
+  const res = await handler(
+    new Request("https://kipclip.com/api/stats/monthly?months=3"),
+  );
+  assertEquals(res.status, 200);
+  const body = await res.json();
+  assertEquals(typeof body.currentYearMonth, "string");
+  assertEquals(body.months.length, 3);
+  for (const m of body.months) {
+    assert(
+      typeof m.yearMonth === "string" && /^\d{4}-\d{2}$/.test(m.yearMonth),
+    );
+    assertEquals(typeof m.mau, "number");
+    assertEquals(typeof m.signups, "number");
+  }
+  // Current month must contain our newly-inserted user.
+  const current = body.months.find((m: { yearMonth: string }) =>
+    m.yearMonth === body.currentYearMonth
+  );
+  assert(current);
+  assert(current.mau >= 1);
+  assert(current.signups >= 1);
+  // Public, cacheable.
+  const cc = res.headers.get("cache-control") ?? "";
+  assert(cc.includes("public"));
+});
+
+Deno.test("GET /api/stats/monthly defaults to 12 months", async () => {
+  await clearFixtures();
+  const res = await handler(
+    new Request("https://kipclip.com/api/stats/monthly"),
+  );
+  assertEquals(res.status, 200);
+  const body = await res.json();
+  assertEquals(body.months.length, 12);
+});
+
+Deno.test("GET /api/stats/monthly rejects out-of-range months", async () => {
+  for (const bad of ["0", "-1", String(MAX_MONTHS + 1), "abc", "1.5e9"]) {
+    const res = await handler(
+      new Request(`https://kipclip.com/api/stats/monthly?months=${bad}`),
+    );
+    assertEquals(res.status, 400, `months=${bad} should 400`);
+    await res.body?.cancel();
+  }
+});


### PR DESCRIPTION
## Summary
- New public `GET /api/stats/monthly?months=N` endpoint (default 12, capped 24).
- Returns `{ months: [{ yearMonth, mau, signups }], currentYearMonth, stale }`.
- MAU from `iron_session_storage.updated_at`; signups from `seen_dids.first_seen_at`. 1h cached per window.
- Companion to `/api/stats`; powers monthly bar charts on the side-business dashboard after its Turso migration.

## Caveats
- MAU bounded by the 14d iron-session TTL — only the current month is fully reliable; older months decay as sessions evict.
- `seen_dids` backfill stamped pre-migration users at migration time, so the backfill month shows an outsized signup spike.

## Test plan
- [x] `deno task test` — 437 / 0
- [x] `deno task check` clean
- [x] `deno task check:frontend` clean
- [x] `deno fmt --check` clean
- [ ] Hit `/api/stats/monthly` on staging, sanity-check shape + counts
- [ ] Side-business consumer swap in follow-up PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)