### PR TITLE
chore: pre-push hook running deno fmt --check

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Block pushes whose tree fails `deno fmt --check`. CI runs the same check
+# and fails the PR otherwise — catching it locally saves a CI round-trip.
+#
+# One-time setup per clone:
+#   git config core.hooksPath .githooks
+
+set -euo pipefail
+
+if ! command -v deno >/dev/null 2>&1; then
+  echo "pre-push: deno not on PATH — skipping fmt check" >&2
+  exit 0
+fi
+
+if ! deno fmt --check; then
+  echo "" >&2
+  echo "pre-push: deno fmt --check failed. Run \`deno fmt\` and amend/commit." >&2
+  exit 1
+fi

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -71,6 +71,13 @@ so OAuth redirects work correctly.
    http://localhost:8000
    ```
 
+5. **Enable the repo's git hooks (one-time per clone)**
+   ```bash
+   git config core.hooksPath .githooks
+   ```
+   Runs `deno fmt --check` on every `git push` so a missed format never reaches
+   CI. Skips silently if `deno` isn't on `PATH`.
+
 ## Development Setup
 
 ### Environment Configuration


### PR DESCRIPTION
## Summary
- Adds `.githooks/pre-push` that runs `deno fmt --check` before any push.
- Documents the one-time opt-in in `DEVELOPMENT.md`:
  ```sh
  git config core.hooksPath .githooks
  ```
- Skips silently when `deno` isn't on `PATH` so contributors without a Deno install can still push (e.g. doc-only edits from another workstation).

## Why
Every recent PR has tripped the CI `Format check` step on a single unformatted file, costing a full CI round-trip per fix. Running the same check locally before push catches it in 1s.

## Test plan
- [x] Hook smoke-tested locally: blocks on dirty tree with non-zero exit, passes on clean tree.
- [x] Pushed this branch through the hook itself (it caught its own missing fmt on the DEVELOPMENT.md edit; pushed clean after `deno fmt`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)